### PR TITLE
グループの表示

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,14 +4,13 @@
     .content-header
       .content-header__group
         .content-header__group__group-name
-          test
+          = @group.name
         %ul.content-header__group__member
           Member：
-          %li.content-header__group__member__name
-            tarou
-          %li.content-header__group__member__name
-            jirou
-      = link_to "/groups/1/edit" do
+          - @group.users.each do |user|
+            %li.content-header__group__member__name
+              = user.name
+      = link_to edit_group_path(@group) do
         .content-header__btn
           Edit
     .main-chat


### PR DESCRIPTION
#What
indexにグループ名、グループメンバーの表示を記述。
グループ編集へのリンクの記述。

#Why 
グループについての詳細が見れるようにするため