### PR TITLE
メッセージ投稿についてのフラッシュメッセージ表示

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,6 +12,7 @@ class MessagesController < ApplicationController
       redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
     else
       @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end
   end


### PR DESCRIPTION
#What
messages_controllerのcreateアクションにフラッシュメッセージの記述。

#why
メッセージの投稿の成功と失敗をわかりやすくするため